### PR TITLE
Query for max amount of following channels

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -70,7 +70,7 @@ Item {
             console.log("Starting update");
             twitchRequest("users", function(res) {
                 let userId = res.data[0].id;
-                twitchRequest("users/follows?from_id="+userId, function(res) {
+                twitchRequest("users/follows?from_id="+userId+"&first=100", function(res) {
                     let query = [];
                     for (let followed of res.data) {
                         query.push("id="+followed.to_id);


### PR DESCRIPTION
https://dev.twitch.tv/docs/api/reference#get-users-follows

> Maximum number of objects to return. Maximum: 100. Default: 20.

I might implement pagination as soon as I figure out how QML works. But for now, I think this will do for many more use cases. I tested quickly, so if you spot any problems this might cause, then tell me. 