### PR TITLE
Add game being played by channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Displays active streams from channels you're following on twitch.
 Now it's a beta version, so don't hesitate to report bugs and request some improvements.
 
 Roadmap:
-- add games information to the stream list
 - add youtube support
 - update the code to support more than 100 active streams, display search if the list is too big
 - option to play stream directly in widget. Add pin feature.

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -204,16 +204,36 @@ Item {
                         }
                     }
 
-                    PlasmaComponents.Label {
-                        id: streamName
+                    Item {
+                        id: channelSubheader
                         anchors.top: channelHeader.bottom
                         anchors.left: channelIcon.right
                         anchors.leftMargin: units.largeSpacing
-                        anchors.bottom: parent.bottom
                         anchors.right: parent.right
-                        text: model.title
-                        elide: Text.ElideRight
-                        opacity: 0.6
+                        anchors.bottom: parent.bottom
+
+                        PlasmaComponents.Label {
+                            id: streamGame
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            anchors.bottom: parent.bottom
+                            text: model.game_name
+                            elide: Text.ElideLeft
+                            width: implicitWidth
+                            opacity: 0.6
+                        }
+
+                        PlasmaComponents.Label {
+                            id: streamName
+                            anchors.top: parent.top
+                            anchors.left: parent.left
+                            anchors.right: streamGame.left
+                            anchors.bottom: parent.bottom
+                            anchors.rightMargin: units.largeSpacing
+                            text: model.title
+                            elide: Text.ElideRight
+                            opacity: 0.6
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I found that a lot of times when I was looking at channels I'd wonder what they were playing.
Puts the current game being played by the channel under the viewer total:
![Screenshot_20211117_235530](https://user-images.githubusercontent.com/16393543/142374853-54d6412d-1474-4da4-9e68-793219928210.png)
